### PR TITLE
MajorityCollector should handle case of empty list of Futures

### DIFF
--- a/barge-core/src/main/java/org/robotninjas/barge/state/MajorityCollector.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/MajorityCollector.java
@@ -54,6 +54,9 @@ class MajorityCollector<T> extends AbstractFuture<Boolean> implements FutureCall
     for (ListenableFuture<U> response : responses) {
       Futures.addCallback(response, collector);
     }
+    if (responses.isEmpty()) {
+      collector.checkComplete();
+    }
     return collector;
   }
 


### PR DESCRIPTION
We now check if we are complete immediately if we have no futures.

This happens when we set up a single node cluster.
