### PR TITLE
Verify the previous state as part of every state transition

### DIFF
--- a/barge-core/src/main/java/org/robotninjas/barge/RaftService.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/RaftService.java
@@ -68,7 +68,7 @@ public class RaftService extends AbstractService {
 
     try {
 
-      ctx.setState(START);
+      ctx.setState(null, START);
 
       RaftServiceEndpoint endpoint = new RaftServiceEndpoint(ctx);
       Service replicaService = RaftProto.RaftService.newReflectiveService(endpoint);

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Candidate.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Candidate.java
@@ -110,7 +110,7 @@ class Candidate extends BaseState {
   }
 
   private void transition(@Nonnull RaftStateContext ctx, @Nonnull RaftStateContext.StateType state) {
-    ctx.setState(state);
+    ctx.setState(this, state);
     electionResult.cancel(false);
     electionTimer.cancel();
   }

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Follower.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Follower.java
@@ -65,7 +65,7 @@ class Follower extends BaseState {
       @Override
       public void run() {
         LOGGER.debug("DeadlineTimer expired, starting election");
-        ctx.setState(CANDIDATE);
+        ctx.setState(Follower.this, CANDIDATE);
       }
     }, timeout * 2);
   }
@@ -142,6 +142,5 @@ class Follower extends BaseState {
       throw new NoLeaderException();
     }
   }
-
 
 }

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Leader.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Leader.java
@@ -89,7 +89,7 @@ class Leader extends BaseState {
     for (ReplicaManager mgr : managers.values()) {
       mgr.shutdown();
     }
-    ctx.setState(FOLLOWER);
+    ctx.setState(this, FOLLOWER);
   }
 
   @Nonnull

--- a/barge-core/src/main/java/org/robotninjas/barge/state/RaftStateContext.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/RaftStateContext.java
@@ -63,7 +63,14 @@ public class RaftStateContext {
     return delegate.commitOperation(this, op);
   }
 
-  public void setState(@Nonnull StateType state) {
+  public synchronized void setState(@Nonnull State oldState, @Nonnull StateType state) {
+    if (this.delegate != oldState) {
+      LOGGER.warn("State transition from incorrect previous state.  Expected {}, was {}",
+              this.delegate,
+              oldState);
+      throw new IllegalStateException();
+    }
+
     LOGGER.info("old state: {}, new state: {}", this.state, state);
     this.state = checkNotNull(state);
     switch (state) {

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Start.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Start.java
@@ -23,7 +23,7 @@ class Start implements State {
   @Override
   public void init(@Nonnull RaftStateContext ctx) {
     log.load();
-    ctx.setState(FOLLOWER);
+    ctx.setState(this, FOLLOWER);
   }
 
   @Nonnull

--- a/barge-core/src/test/java/org/robotninjas/barge/state/CandidateTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/CandidateTest.java
@@ -82,8 +82,8 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext, times(1)).setState(FOLLOWER);
-    verify(mockRaftStateContext, times(1)).setState(LEADER);
+    verify(mockRaftStateContext, times(1)).setState(any(Candidate.class), eq(FOLLOWER));
+    verify(mockRaftStateContext, times(1)).setState(any(Candidate.class), eq(LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 
@@ -115,7 +115,7 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(LEADER);
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
 
     verifyZeroInteractions(mockRaftClient);
   }
@@ -146,7 +146,7 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(any(RaftStateContext.StateType.class));
+    verify(mockRaftStateContext).setState(any(State.class), any(RaftStateContext.StateType.class));
 
     verifyZeroInteractions(mockRaftStateContext);
 
@@ -181,8 +181,8 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(FOLLOWER);
-    verify(mockRaftStateContext).setState(LEADER);
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(FOLLOWER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 
@@ -215,7 +215,7 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(LEADER);
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 
@@ -246,8 +246,8 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(FOLLOWER);
-    verify(mockRaftStateContext).setState(LEADER);
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(FOLLOWER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 

--- a/barge-core/src/test/java/org/robotninjas/barge/state/DefaultContextTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/DefaultContextTest.java
@@ -37,7 +37,7 @@ public class DefaultContextTest {
 
     RaftStateContext ctx = new RaftStateContext(mockStateFactory);
 
-    ctx.setState(StateType.FOLLOWER);
+    ctx.setState(null, StateType.FOLLOWER);
       
     verify(mockFollower).init(ctx);
     assertEquals(StateType.FOLLOWER, ctx.getState());
@@ -51,7 +51,7 @@ public class DefaultContextTest {
     verifyNoMoreInteractions(mockFollower);
 
 
-    ctx.setState(StateType.LEADER);
+    ctx.setState(mockFollower, StateType.LEADER);
     verify(mockLeader).init(ctx);
     assertEquals(StateType.LEADER, ctx.getState());
 
@@ -64,7 +64,7 @@ public class DefaultContextTest {
     verifyNoMoreInteractions(mockLeader);
 
 
-    ctx.setState(StateType.CANDIDATE);
+    ctx.setState(mockLeader, StateType.CANDIDATE);
     verify(mockCandidate).init(ctx);
     assertEquals(StateType.CANDIDATE, ctx.getState());
 


### PR DESCRIPTION
I became worried about the threading logic, for example in Candidate, there seems to be a race condition between the timeout & the callback.  It is cheap to self-check the state transitions by passing in the previous state.
