### PR TITLE
Extract Raft interface from Context

### DIFF
--- a/barge-core/src/main/java/org/robotninjas/barge/RaftCoreModule.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/RaftCoreModule.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.PrivateModule;
 import org.robotninjas.barge.log.LogModule;
 import org.robotninjas.barge.rpc.Client;
-import org.robotninjas.barge.state.RaftStateContext;
+import org.robotninjas.barge.state.Raft;
 import org.robotninjas.barge.state.StateModule;
 
 import javax.annotation.Nonnull;
@@ -55,7 +55,7 @@ class RaftCoreModule extends PrivateModule {
   protected void configure() {
 
     install(new StateModule(timeout));
-    expose(RaftStateContext.class);
+    expose(Raft.class);
 
     final ListeningExecutorService executor;
     if (stateMachineExecutor.isPresent()) {

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Candidate.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Candidate.java
@@ -44,7 +44,7 @@ import static com.google.common.util.concurrent.Futures.addCallback;
 import static org.robotninjas.barge.proto.RaftProto.*;
 import static org.robotninjas.barge.state.MajorityCollector.majorityResponse;
 import static org.robotninjas.barge.state.RaftPredicates.voteGranted;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.*;
+import static org.robotninjas.barge.state.Raft.StateType.*;
 
 @NotThreadSafe
 class Candidate extends BaseState {

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Follower.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Follower.java
@@ -36,8 +36,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.robotninjas.barge.proto.RaftProto.*;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.CANDIDATE;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.FOLLOWER;
+import static org.robotninjas.barge.state.Raft.StateType.CANDIDATE;
+import static org.robotninjas.barge.state.Raft.StateType.FOLLOWER;
 
 @NotThreadSafe
 class Follower extends BaseState {

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Leader.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Leader.java
@@ -47,8 +47,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Lists.newArrayList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.robotninjas.barge.proto.RaftProto.*;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.FOLLOWER;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.LEADER;
+import static org.robotninjas.barge.state.Raft.StateType.FOLLOWER;
+import static org.robotninjas.barge.state.Raft.StateType.LEADER;
 
 @NotThreadSafe
 class Leader extends BaseState {

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Raft.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Raft.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2013-2014 David Rusek <dave dot rusek at gmail dot com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.robotninjas.barge.state;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import org.robotninjas.barge.RaftException;
+
+import javax.annotation.Nonnull;
+
+import static org.robotninjas.barge.proto.RaftProto.*;
+
+/**
+ * Main interface to a Raft protocol instance.
+ */
+public interface Raft {
+
+  @Nonnull
+  RequestVoteResponse requestVote(@Nonnull RequestVote request);
+
+  @Nonnull
+  AppendEntriesResponse appendEntries(@Nonnull AppendEntries request);
+
+  @Nonnull
+  ListenableFuture<Object> commitOperation(@Nonnull byte[] op) throws RaftException;
+
+  void setState(State oldState, @Nonnull StateType state);
+
+  void addTransitionListener(@Nonnull StateTransitionListener transitionListener);
+
+  @Nonnull
+  StateType type();
+
+  public static enum StateType {START, FOLLOWER, CANDIDATE, LEADER}
+}

--- a/barge-core/src/main/java/org/robotninjas/barge/state/RaftStateContext.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/RaftStateContext.java
@@ -33,9 +33,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.robotninjas.barge.proto.RaftProto.*;
 
 @NotThreadSafe
-public class RaftStateContext {
-
-  public enum StateType {START, FOLLOWER, CANDIDATE, LEADER}
+class RaftStateContext implements Raft {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RaftStateContext.class);
 
@@ -51,24 +49,28 @@ public class RaftStateContext {
     this.listeners.add(new LogListener());
   }
 
+  @Override
   @Nonnull
   public RequestVoteResponse requestVote(@Nonnull RequestVote request) {
     checkNotNull(request);
     return delegate.requestVote(this, request);
   }
 
+  @Override
   @Nonnull
   public AppendEntriesResponse appendEntries(@Nonnull AppendEntries request) {
     checkNotNull(request);
     return delegate.appendEntries(this, request);
   }
 
+  @Override
   @Nonnull
   public ListenableFuture<Object> commitOperation(@Nonnull byte[] op) throws RaftException {
     checkNotNull(op);
     return delegate.commitOperation(this, op);
   }
 
+  @Override
   public synchronized void setState(State oldState, @Nonnull StateType state) {
     if (this.delegate != oldState) {
       notifiesInvalidTransition(oldState);
@@ -109,23 +111,25 @@ public class RaftStateContext {
     }
   }
 
+  @Override
   public void addTransitionListener(@Nonnull StateTransitionListener transitionListener) {
     listeners.add(transitionListener);
   }
 
+  @Override
   @Nonnull
-  public StateType getState() {
+  public StateType type() {
     return state;
   }
 
   private class LogListener implements StateTransitionListener {
     @Override
-    public void changeState(@Nonnull RaftStateContext context, @Nullable StateType from, @Nonnull StateType to) {
+    public void changeState(@Nonnull Raft context, @Nullable StateType from, @Nonnull StateType to) {
       LOGGER.info("old state: {}, new state: {}", from, to);
     }
 
     @Override
-    public void invalidTransition(@Nonnull RaftStateContext context, @Nonnull StateType actual, @Nullable StateType expected) {
+    public void invalidTransition(@Nonnull Raft context, @Nonnull StateType actual, @Nullable StateType expected) {
       LOGGER.warn("State transition from incorrect previous state.  Expected {}, was {}", actual, expected);
     }
   }

--- a/barge-core/src/main/java/org/robotninjas/barge/state/Start.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/Start.java
@@ -9,8 +9,8 @@ import javax.annotation.Nonnull;
 
 import static com.google.inject.internal.util.$Preconditions.checkNotNull;
 import static org.robotninjas.barge.proto.RaftProto.*;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.FOLLOWER;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.START;
+import static org.robotninjas.barge.state.Raft.StateType.FOLLOWER;
+import static org.robotninjas.barge.state.Raft.StateType.START;
 
 class Start implements State {
 

--- a/barge-core/src/main/java/org/robotninjas/barge/state/StateModule.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/StateModule.java
@@ -40,9 +40,11 @@ public class StateModule extends PrivateModule {
       .annotatedWith(ElectionTimeout.class)
       .toInstance(electionTimeout);
 
-    bind(RaftStateContext.class)
+    bind(Raft.class)
+      .to(RaftStateContext.class)
       .asEagerSingleton();
-    expose(RaftStateContext.class);
+
+    expose(Raft.class);
 
   }
 

--- a/barge-core/src/main/java/org/robotninjas/barge/state/StateTransitionListener.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/StateTransitionListener.java
@@ -33,7 +33,7 @@ public interface StateTransitionListener {
    * @param from    previous state of replica.
    * @param to      current state of replica.
    */
-  void changeState(@Nonnull RaftStateContext context, @Nullable StateType from, @Nonnull StateType to);
+  void changeState(@Nonnull Raft context, @Nullable StateType from, @Nonnull StateType to);
 
   /**
    * Called when a transition is requested from an invalid state.
@@ -43,5 +43,5 @@ public interface StateTransitionListener {
    * @param actual   the actual state registered in context.
    * @param expected the expected state as requested by transition.
    */
-  void invalidTransition(@Nonnull RaftStateContext context, @Nonnull StateType actual, @Nullable StateType expected);
+  void invalidTransition(@Nonnull Raft context, @Nonnull StateType actual, @Nullable StateType expected);
 }

--- a/barge-core/src/test/java/org/robotninjas/barge/state/CandidateTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/CandidateTest.java
@@ -20,8 +20,6 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.*;
 import static org.robotninjas.barge.proto.RaftProto.AppendEntries;
 import static org.robotninjas.barge.proto.RaftProto.RequestVote;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.FOLLOWER;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.LEADER;
 
 public class CandidateTest {
 
@@ -82,8 +80,8 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext, times(1)).setState(any(Candidate.class), eq(FOLLOWER));
-    verify(mockRaftStateContext, times(1)).setState(any(Candidate.class), eq(LEADER));
+    verify(mockRaftStateContext, times(1)).setState(any(Candidate.class), eq(Raft.StateType.FOLLOWER));
+    verify(mockRaftStateContext, times(1)).setState(any(Candidate.class), eq(Raft.StateType.LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 
@@ -115,7 +113,7 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(Raft.StateType.LEADER));
 
     verifyZeroInteractions(mockRaftClient);
   }
@@ -181,8 +179,8 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(any(Candidate.class), eq(FOLLOWER));
-    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(Raft.StateType.FOLLOWER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(Raft.StateType.LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 
@@ -215,7 +213,7 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(Raft.StateType.LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 
@@ -246,8 +244,8 @@ public class CandidateTest {
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
-    verify(mockRaftStateContext).setState(any(Candidate.class), eq(FOLLOWER));
-    verify(mockRaftStateContext).setState(any(Candidate.class), eq(LEADER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(Raft.StateType.FOLLOWER));
+    verify(mockRaftStateContext).setState(any(Candidate.class), eq(Raft.StateType.LEADER));
 
     verifyZeroInteractions(mockRaftClient);
 

--- a/barge-core/src/test/java/org/robotninjas/barge/state/DefaultContextTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/DefaultContextTest.java
@@ -40,7 +40,7 @@ public class DefaultContextTest {
     ctx.setState(null, StateType.FOLLOWER);
       
     verify(mockFollower).init(ctx);
-    assertEquals(StateType.FOLLOWER, ctx.getState());
+    assertEquals(StateType.FOLLOWER, ctx.type());
 
     ctx.appendEntries(appendEntries);
     verify(mockFollower).appendEntries(ctx, appendEntries);
@@ -53,7 +53,7 @@ public class DefaultContextTest {
 
     ctx.setState(mockFollower, StateType.LEADER);
     verify(mockLeader).init(ctx);
-    assertEquals(StateType.LEADER, ctx.getState());
+    assertEquals(StateType.LEADER, ctx.type());
 
     ctx.appendEntries(appendEntries);
     verify(mockLeader).appendEntries(ctx, appendEntries);
@@ -66,7 +66,7 @@ public class DefaultContextTest {
 
     ctx.setState(mockLeader, StateType.CANDIDATE);
     verify(mockCandidate).init(ctx);
-    assertEquals(StateType.CANDIDATE, ctx.getState());
+    assertEquals(StateType.CANDIDATE, ctx.type());
 
     ctx.appendEntries(appendEntries);
     verify(mockCandidate).appendEntries(ctx, appendEntries);

--- a/barge-core/src/test/java/org/robotninjas/barge/state/RaftStateContextTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/RaftStateContextTest.java
@@ -19,7 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.mockito.Mockito.*;
-import static org.robotninjas.barge.state.RaftStateContext.StateType.*;
+import static org.robotninjas.barge.state.Raft.StateType.*;
 
 public class RaftStateContextTest {
 

--- a/barge-service/src/main/java/org/robotninjas/barge/RaftServiceEndpoint.java
+++ b/barge-service/src/main/java/org/robotninjas/barge/RaftServiceEndpoint.java
@@ -3,7 +3,7 @@ package org.robotninjas.barge;
 import com.google.protobuf.RpcCallback;
 import com.google.protobuf.RpcController;
 import org.robotninjas.barge.proto.RaftProto;
-import org.robotninjas.barge.state.RaftStateContext;
+import org.robotninjas.barge.state.Raft;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,9 +16,9 @@ class RaftServiceEndpoint implements RaftProto.RaftService.Interface {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RaftServiceEndpoint.class);
 
-  private final RaftStateContext ctx;
+  private final Raft ctx;
 
-  public RaftServiceEndpoint(RaftStateContext ctx) {
+  public RaftServiceEndpoint(Raft ctx) {
     this.ctx = ctx;
   }
 

--- a/barge-service/src/test/java/org/robotninjas/barge/GroupOfCounters.java
+++ b/barge-service/src/test/java/org/robotninjas/barge/GroupOfCounters.java
@@ -18,7 +18,7 @@ package org.robotninjas.barge;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.junit.rules.ExternalResource;
-import org.robotninjas.barge.state.RaftStateContext;
+import org.robotninjas.barge.state.Raft;
 import org.robotninjas.barge.state.StateTransitionListener;
 
 import javax.annotation.Nonnull;
@@ -28,14 +28,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import static org.robotninjas.barge.state.RaftStateContext.StateType;
+import static org.robotninjas.barge.state.Raft.StateType;
 
 public class GroupOfCounters extends ExternalResource implements StateTransitionListener {
 
   private final List<Replica> replicas;
   private final List<SimpleCounterMachine> counters;
   private final File target;
-  private final Map<RaftStateContext, StateType> states = Maps.newConcurrentMap();
+  private final Map<Raft, StateType> states = Maps.newConcurrentMap();
 
   public GroupOfCounters(int numberOfReplicas, File target) {
     this.target = target;
@@ -107,13 +107,14 @@ public class GroupOfCounters extends ExternalResource implements StateTransition
     return numberOfLeaders == 1 && (numberOfFollowers + numberOfLeaders == replicas.size());
   }
 
+
   @Override
-  public void changeState(@Nonnull RaftStateContext context, @Nullable StateType from, @Nonnull StateType to) {
+  public void changeState(@Nonnull Raft context, @Nullable StateType from, @Nonnull StateType to) {
     states.put(context, to);
   }
 
   @Override
-  public void invalidTransition(@Nonnull RaftStateContext context, @Nonnull StateType actual, @Nullable StateType expected) {
+  public void invalidTransition(@Nonnull Raft context, @Nonnull StateType actual, @Nullable StateType expected) {
     // IGNORED
   }
 }


### PR DESCRIPTION
Goal is to have a RaftStateContext handle requests on its own thread without relying on transport layer's thread. First step is to have an interface possibly exposing methods returning `Future` (implemented with immediate futures while waiting for threading modifications to reach master...) and hide RaftStateContext implementation details.
