### PR TITLE
Fix the voting logic to match the Raft paper

### DIFF
--- a/barge-core/src/main/java/org/robotninjas/barge/log/RaftLog.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/log/RaftLog.java
@@ -223,15 +223,16 @@ public class RaftLog {
     MDC.put("term", Long.toString(term));
     LOGGER.debug("New term {}", term);
     currentTerm = term;
+    votedFor = Optional.absent();
     journal.appendTerm(term);
   }
 
   @Nonnull
-  public Optional<Replica> lastVotedFor() {
+  public Optional<Replica> votedFor() {
     return votedFor;
   }
 
-  public void lastVotedFor(@Nonnull Optional<Replica> vote) {
+  public void votedFor(@Nonnull Optional<Replica> vote) {
     LOGGER.debug("Voting for {}", vote.orNull());
     votedFor = vote;
     journal.appendVote(vote);

--- a/barge-core/src/main/java/org/robotninjas/barge/state/MajorityCollector.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/MajorityCollector.java
@@ -49,7 +49,7 @@ class MajorityCollector<T> extends AbstractFuture<Boolean> implements FutureCall
   }
 
   @Nonnull
-  public static <U> ListenableFuture<Boolean> majorityResponse(@Nonnull List<ListenableFuture<U>> responses, @Nonnull Predicate<U> isSuccess) {
+  public static <U> ListenableFuture<Boolean> majorityResponse(@Nonnull List<? extends ListenableFuture<U>> responses, @Nonnull Predicate<U> isSuccess) {
     MajorityCollector collector = new MajorityCollector(responses.size(), isSuccess);
     for (ListenableFuture<U> response : responses) {
       Futures.addCallback(response, collector);
@@ -63,9 +63,9 @@ class MajorityCollector<T> extends AbstractFuture<Boolean> implements FutureCall
   private void checkComplete() {
     if (!isDone()) {
       final double half = totalNum / 2.0;
-      if (numSuccess >= half) {
+      if (numSuccess > half) {
         set(true);
-      } else if (numFailed > half) {
+      } else if (numFailed >= half) {
         set(false);
       }
     }

--- a/barge-core/src/main/java/org/robotninjas/barge/state/RaftStateContext.java
+++ b/barge-core/src/main/java/org/robotninjas/barge/state/RaftStateContext.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ListenableFutureTask;
 import org.jetlang.fibers.Fiber;
 import org.robotninjas.barge.RaftException;
 import org.robotninjas.barge.RaftExecutor;
+import org.robotninjas.barge.log.RaftLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -36,7 +37,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 import static org.robotninjas.barge.proto.RaftProto.*;
 
 @NotThreadSafe
@@ -51,8 +51,15 @@ class RaftStateContext implements Raft {
   private volatile StateType state;
   private volatile State delegate;
 
+
   @Inject
-  RaftStateContext(StateFactory stateFactory, @RaftExecutor Fiber executor) {
+  RaftStateContext(RaftLog log, StateFactory stateFactory, @RaftExecutor Fiber executor) {
+    this(log.self().toString(), stateFactory, executor);
+  }
+
+  RaftStateContext(String name, StateFactory stateFactory, @RaftExecutor Fiber executor) {
+    MDC.put("self", name);
+
     this.stateFactory = stateFactory;
     this.executor = executor;
     this.listeners.add(new LogListener());
@@ -130,11 +137,12 @@ class RaftStateContext implements Raft {
   public synchronized void setState(State oldState, @Nonnull StateType state) {
 
     if (this.delegate != oldState) {
+      LOGGER.info("Previous state was not correct (transitioning to {}). Expected {}, was {}", state, oldState, this.delegate);
       notifiesInvalidTransition(oldState);
       throw new IllegalStateException();
     }
 
-    LOGGER.info("old state: {}, new state: {}", this.state, state);
+    LOGGER.info("Transition: old state: {}, new state: {}", this.state, state);
     if (this.delegate != null) {
       this.delegate.destroy(this);
     }
@@ -176,12 +184,12 @@ class RaftStateContext implements Raft {
   private class LogListener implements StateTransitionListener {
     @Override
     public void changeState(@Nonnull Raft context, @Nullable StateType from, @Nonnull StateType to) {
-      LOGGER.info("old state: {}, new state: {}", from, to);
+      LOGGER.info("LogListener: old state: {}, new state: {}", from, to);
     }
 
     @Override
     public void invalidTransition(@Nonnull Raft context, @Nonnull StateType actual, @Nullable StateType expected) {
-      LOGGER.warn("State transition from incorrect previous state.  Expected {}, was {}", actual, expected);
+      LOGGER.warn("LogListener: State transition from incorrect previous state.  Expected {}, was {}", actual, expected);
     }
   }
 }

--- a/barge-core/src/test/java/org/robotninjas/barge/state/BaseStateTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/BaseStateTest.java
@@ -63,7 +63,7 @@ public class BaseStateTest {
       .setTerm(2)
       .build();
 
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.<Replica>absent());
+    when(mockRaftLog.votedFor()).thenReturn(Optional.<Replica>absent());
     boolean shouldVote = state.shouldVoteFor(mockRaftLog, requestVote);
 
     assertTrue(shouldVote);
@@ -81,7 +81,7 @@ public class BaseStateTest {
       .setTerm(2)
       .build();
 
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.of(candidate));
+    when(mockRaftLog.votedFor()).thenReturn(Optional.of(candidate));
     boolean shouldVote = state.shouldVoteFor(mockRaftLog, requestVote);
 
     assertTrue(shouldVote);
@@ -101,7 +101,7 @@ public class BaseStateTest {
       .build();
 
     Replica otherCandidate = config.getReplica("other");
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.of(otherCandidate));
+    when(mockRaftLog.votedFor()).thenReturn(Optional.of(otherCandidate));
     boolean shouldVote = state.shouldVoteFor(mockRaftLog, requestVote);
 
     assertTrue(shouldVote);
@@ -120,7 +120,7 @@ public class BaseStateTest {
       .build();
 
     Replica otherCandidate = config.getReplica("other");
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.of(otherCandidate));
+    when(mockRaftLog.votedFor()).thenReturn(Optional.of(otherCandidate));
     boolean shouldVote = state.shouldVoteFor(mockRaftLog, requestVote);
 
     assertFalse(shouldVote);
@@ -139,7 +139,7 @@ public class BaseStateTest {
       .build();
 
     Replica otherCandidate = config.getReplica("other");
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.of(otherCandidate));
+    when(mockRaftLog.votedFor()).thenReturn(Optional.of(otherCandidate));
     boolean shouldVote = state.shouldVoteFor(mockRaftLog, requestVote);
 
     assertFalse(shouldVote);
@@ -159,7 +159,7 @@ public class BaseStateTest {
       .build();
 
     Replica otherCandidate = config.getReplica("other");
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.of(otherCandidate));
+    when(mockRaftLog.votedFor()).thenReturn(Optional.of(otherCandidate));
     boolean shouldVote = state.shouldVoteFor(mockRaftLog, requestVote);
 
     assertTrue(shouldVote);

--- a/barge-core/src/test/java/org/robotninjas/barge/state/CandidateTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/CandidateTest.java
@@ -43,7 +43,7 @@ public class CandidateTest {
     MockitoAnnotations.initMocks(this);
 
     when(mockRaftLog.self()).thenReturn(self);
-    when(mockRaftLog.lastVotedFor()).thenReturn(Optional.<Replica>absent());
+    when(mockRaftLog.votedFor()).thenReturn(Optional.<Replica>absent());
     when(mockRaftLog.lastLogTerm()).thenReturn(0L);
     when(mockRaftLog.lastLogIndex()).thenReturn(0L);
     when(mockRaftLog.currentTerm()).thenReturn(term);
@@ -84,9 +84,9 @@ public class CandidateTest {
     verify(mockRaftLog).currentTerm(4L);
     verify(mockRaftLog, times(2)).currentTerm(anyLong());
 
-    verify(mockRaftLog).lastVotedFor(Optional.of(self));
-    verify(mockRaftLog).lastVotedFor(Optional.of(mockCandidate));
-    verify(mockRaftLog, times(2)).lastVotedFor(any(Optional.class));
+    verify(mockRaftLog).votedFor(Optional.of(self));
+    verify(mockRaftLog).votedFor(Optional.of(mockCandidate));
+    verify(mockRaftLog, times(2)).votedFor(any(Optional.class));
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
@@ -117,9 +117,9 @@ public class CandidateTest {
     verify(mockRaftLog).currentTerm(3L);
     verify(mockRaftLog, times(1)).currentTerm(anyLong());
 
-    verify(mockRaftLog).lastVotedFor(Optional.of(self));
-    verify(mockRaftLog, never()).lastVotedFor(Optional.of(mockCandidate));
-    verify(mockRaftLog, times(1)).lastVotedFor(any(Optional.class));
+    verify(mockRaftLog).votedFor(Optional.of(self));
+    verify(mockRaftLog, never()).votedFor(Optional.of(mockCandidate));
+    verify(mockRaftLog, times(1)).votedFor(any(Optional.class));
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
@@ -148,9 +148,9 @@ public class CandidateTest {
     verify(mockRaftLog).currentTerm(3L);
     verify(mockRaftLog, times(1)).currentTerm(anyLong());
 
-    verify(mockRaftLog).lastVotedFor(Optional.of(self));
-    verify(mockRaftLog, times(1)).lastVotedFor(Optional.of(mockCandidate));
-    verify(mockRaftLog, times(2)).lastVotedFor(any(Optional.class));
+    verify(mockRaftLog).votedFor(Optional.of(self));
+    verify(mockRaftLog, times(1)).votedFor(Optional.of(mockCandidate));
+    verify(mockRaftLog, times(2)).votedFor(any(Optional.class));
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
@@ -184,8 +184,8 @@ public class CandidateTest {
     verify(mockRaftLog).currentTerm(4L);
     verify(mockRaftLog, times(2)).currentTerm(anyLong());
 
-    verify(mockRaftLog).lastVotedFor(Optional.of(self));
-    verify(mockRaftLog, times(1)).lastVotedFor(any(Optional.class));
+    verify(mockRaftLog).votedFor(Optional.of(self));
+    verify(mockRaftLog, times(1)).votedFor(any(Optional.class));
 
     verify(mockRaftLog, times(1)).commitIndex(anyLong());
 
@@ -218,8 +218,8 @@ public class CandidateTest {
     verify(mockRaftLog).currentTerm(3L);
     verify(mockRaftLog, times(1)).currentTerm(anyLong());
 
-    verify(mockRaftLog).lastVotedFor(Optional.of(self));
-    verify(mockRaftLog, times(1)).lastVotedFor(any(Optional.class));
+    verify(mockRaftLog).votedFor(Optional.of(self));
+    verify(mockRaftLog, times(1)).votedFor(any(Optional.class));
 
     verify(mockRaftLog, never()).commitIndex(anyLong());
 
@@ -249,8 +249,8 @@ public class CandidateTest {
     verify(mockRaftLog).currentTerm(3L);
     verify(mockRaftLog, times(1)).currentTerm(anyLong());
 
-    verify(mockRaftLog).lastVotedFor(Optional.of(self));
-    verify(mockRaftLog, times(1)).lastVotedFor(any(Optional.class));
+    verify(mockRaftLog).votedFor(Optional.of(self));
+    verify(mockRaftLog, times(1)).votedFor(any(Optional.class));
 
     verify(mockRaftLog, times(1)).commitIndex(anyLong());
 

--- a/barge-core/src/test/java/org/robotninjas/barge/state/MajorityCollectorTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/MajorityCollectorTest.java
@@ -138,11 +138,12 @@ public class MajorityCollectorTest {
   }
 
   @Test
-  public void testEvenSplitAllCompleted() {
+  public void testBareMajorityTrueAllCompleted() {
 
     List<ListenableFuture<Boolean>> responses = Lists.newArrayList(
       Futures.<Boolean>immediateFuture(Boolean.FALSE),
       Futures.<Boolean>immediateFuture(Boolean.FALSE),
+      Futures.<Boolean>immediateFuture(Boolean.TRUE),
       Futures.<Boolean>immediateFuture(Boolean.TRUE),
       Futures.<Boolean>immediateFuture(Boolean.TRUE)
     );
@@ -154,11 +155,29 @@ public class MajorityCollectorTest {
   }
 
   @Test
-  public void testEvenSplitHalfFailed() {
+  public void testBareMajorityFalseAllCompleted() {
+
+    List<ListenableFuture<Boolean>> responses = Lists.newArrayList(
+      Futures.<Boolean>immediateFuture(Boolean.FALSE),
+      Futures.<Boolean>immediateFuture(Boolean.FALSE),
+      Futures.<Boolean>immediateFuture(Boolean.FALSE),
+      Futures.<Boolean>immediateFuture(Boolean.TRUE),
+      Futures.<Boolean>immediateFuture(Boolean.TRUE)
+    );
+
+    ListenableFuture<Boolean> collector = majorityResponse(responses, Identity);
+
+    assertFalse(Futures.getUnchecked(collector));
+
+  }
+
+  @Test
+  public void testBareMajorityTrueOthersFailed() {
 
     List<ListenableFuture<Boolean>> responses = Lists.newArrayList(
       Futures.<Boolean>immediateFailedFuture(new Exception()),
       Futures.<Boolean>immediateFailedFuture(new Exception()),
+      Futures.<Boolean>immediateFuture(Boolean.TRUE),
       Futures.<Boolean>immediateFuture(Boolean.TRUE),
       Futures.<Boolean>immediateFuture(Boolean.TRUE)
     );
@@ -176,8 +195,8 @@ public class MajorityCollectorTest {
     SettableFuture<Boolean> f2 = SettableFuture.create();
     SettableFuture<Boolean> f3 = SettableFuture.create();
 
-    List<ListenableFuture<Boolean>> responses = Lists.newArrayList(
-      f1, f2, f3, Futures.<Boolean>immediateFuture(Boolean.FALSE)
+    List<SettableFuture<Boolean>> responses = Lists.newArrayList(
+      f1, f2, f3
     );
 
     ListenableFuture<Boolean> collector = majorityResponse(responses, Identity);
@@ -220,9 +239,10 @@ public class MajorityCollectorTest {
     SettableFuture<Boolean> f1 = SettableFuture.create();
     SettableFuture<Boolean> f2 = SettableFuture.create();
     SettableFuture<Boolean> f3 = SettableFuture.create();
+    ListenableFuture<Boolean> f4 = Futures.immediateFuture(Boolean.TRUE);
 
     List<ListenableFuture<Boolean>> responses = Lists.newArrayList(
-      f1, f2, f3, Futures.<Boolean>immediateFuture(Boolean.TRUE)
+      f1, f2, f3, f4
     );
 
     ListenableFuture<Boolean> collector = majorityResponse(responses, Identity);
@@ -230,13 +250,13 @@ public class MajorityCollectorTest {
     f1.setException(new Exception());
     assertFalse(collector.isDone());
 
-    f2.setException(new Exception());
+    f3.set(Boolean.TRUE);
     assertFalse(collector.isDone());
 
-    f3.set(Boolean.TRUE);
+    f2.setException(new Exception());
     assertTrue(collector.isDone());
 
-    assertTrue(Futures.getUnchecked(collector));
+    assertFalse(Futures.getUnchecked(collector));
 
   }
 

--- a/barge-core/src/test/java/org/robotninjas/barge/state/RaftStateContextTest.java
+++ b/barge-core/src/test/java/org/robotninjas/barge/state/RaftStateContextTest.java
@@ -37,7 +37,7 @@ public class RaftStateContextTest {
 
   private final StateTransitionListener transitionListener = mock(StateTransitionListener.class);
 
-  private final RaftStateContext context = new RaftStateContext(factory, executor);
+  private final RaftStateContext context = new RaftStateContext("mockstatecontext", factory, executor);
 
   @Before
   public void setup() {

--- a/barge-rpc-proto/src/test/resources/logback-test.xml
+++ b/barge-rpc-proto/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - {%X{term} %X{state}} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - {%X{self} %X{term} %X{state}} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Tweaks to voting logic, majority now enforces a strict majority.

Also use the new MDC functionality to store the address of the current raft service - very helpful for tests!
